### PR TITLE
Use Finalizer for deletion, and add basic integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -timeout 30s -v -ginkgo.v -coverprofile cover.out
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -timeout 30s -ginkgo.v -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -timeout 30s -ginkgo.v -coverprofile cover.out
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -timeout 30s -v -ginkgo.v -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -v ./... -timeout 30s -ginkgo.v -coverprofile cover.out
 
 ##@ Build
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -31,7 +31,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/nats-io/gnatsd/server"
+
 	corev1beta1 "github.com/wasmCloud/wasmcloud-k8s-operator/api/v1beta1"
+	fakelatticecontroller "github.com/wasmCloud/wasmcloud-k8s-operator/fake_lattice_controller"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -41,6 +44,7 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var natsServer *server.Server
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -91,6 +95,8 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
+	natsServer = fakelatticecontroller.Setup()
+
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
@@ -99,5 +105,6 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	err := testEnv.Stop()
+	natsServer.Shutdown()
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/nats-io/gnatsd/server"
+	"github.com/nats-io/nats-server/v2/server"
 
 	corev1beta1 "github.com/wasmCloud/wasmcloud-k8s-operator/api/v1beta1"
 	fakelatticecontroller "github.com/wasmCloud/wasmcloud-k8s-operator/fake_lattice_controller"

--- a/controllers/wasmcloudapplication_controller.go
+++ b/controllers/wasmcloudapplication_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/go-logr/logr"
 	corev1beta1 "github.com/wasmCloud/wasmcloud-k8s-operator/api/v1beta1"
@@ -40,19 +41,41 @@ type WasmCloudApplicationReconciler struct {
 func (r *WasmCloudApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("wasmcloud-lattice-controller", req.NamespacedName)
 
-	var app corev1beta1.WasmCloudApplication
+	var app *corev1beta1.WasmCloudApplication
 	log.Info("reconciling the requested manifest", "request", req)
 
-	if err := r.Get(ctx, req.NamespacedName, &app); err != nil {
-		(&request.Sender{
-			Log: log,
-		}).Send(request.Message{
-			Name:        req.Name,
-			Namespace:   req.Namespace,
-			Application: nil,
-		})
+	if err := r.Get(ctx, req.NamespacedName, app); err != nil {
+		log.Error(err, "unable to fetch app")
+		// we'll ignore not-found errors, since they can't be fixed by an immediate
+		// requeue (we'll need to wait for a new notification), and we can get them
+		// on deleted requests.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
 
-		return ctrl.Result{}, nil
+	appFinalizerName := "core.wasmcloud.com/finalizer"
+
+	if app.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !containsString(app.GetFinalizers(), appFinalizerName) {
+			controllerutil.AddFinalizer(app, appFinalizerName)
+
+			if err := r.Update(ctx, app); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		if containsString(app.GetFinalizers(), appFinalizerName) {
+			if err := r.deleteExternalResources(app); err != nil {
+				// if fail to delete the external dependency here, return with error
+				// so that it can be retried
+				return ctrl.Result{}, err
+			}
+
+			// remove our finalizer from the list and update it.
+			controllerutil.RemoveFinalizer(app, appFinalizerName)
+			if err := r.Update(ctx, app); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
 	response, err := (&request.Sender{
@@ -71,7 +94,7 @@ func (r *WasmCloudApplicationReconciler) Reconcile(ctx context.Context, req ctrl
 
 	log.Info("response from the lattice controller", "application", response.Status)
 
-	if err := r.Status().Update(context.Background(), &app); err != nil {
+	if err := r.Status().Update(context.Background(), app); err != nil {
 		log.Info("error updating the status", "error", err)
 		return ctrl.Result{}, err
 	}
@@ -85,4 +108,36 @@ func (r *WasmCloudApplicationReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		For(&corev1beta1.WasmCloudApplication{}).
 		Owns(&corev1beta1.WasmCloudApplication{}).
 		Complete(r)
+}
+
+func (r *WasmCloudApplicationReconciler) deleteExternalResources(app *corev1beta1.WasmCloudApplication) error {
+	_, err := (&request.Sender{
+		Log: r.Log,
+	}).Send(request.Message{
+		// FIXME: make this Delete() and make send be Put()
+		Name:        app.Name,
+		Namespace:   app.Namespace,
+		Application: nil,
+	})
+	return err
+}
+
+// Helper functions to check and remove string from a slice of strings.
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
 }

--- a/controllers/wasmcloudapplication_controller.go
+++ b/controllers/wasmcloudapplication_controller.go
@@ -128,13 +128,3 @@ func containsString(slice []string, s string) bool {
 	}
 	return false
 }
-
-// func removeString(slice []string, s string) (result []string) {
-// 	for _, item := range slice {
-// 		if item == s {
-// 			continue
-// 		}
-// 		result = append(result, item)
-// 	}
-// 	return
-// }

--- a/controllers/wasmcloudapplication_controller.go
+++ b/controllers/wasmcloudapplication_controller.go
@@ -39,7 +39,7 @@ type WasmCloudApplicationReconciler struct {
 }
 
 func (r *WasmCloudApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("wasmcloud-lattice-controller", req.NamespacedName)
+	log := r.Log.WithValues("NamespacedName", req.NamespacedName)
 
 	var app *corev1beta1.WasmCloudApplication
 	log.Info("reconciling the requested manifest", "request", req)

--- a/controllers/wasmcloudapplication_controller.go
+++ b/controllers/wasmcloudapplication_controller.go
@@ -75,6 +75,9 @@ func (r *WasmCloudApplicationReconciler) Reconcile(ctx context.Context, req ctrl
 			if err := r.Update(ctx, &app); err != nil {
 				return ctrl.Result{}, err
 			}
+
+			// Stop reconciliation as the item is being deleted
+			return ctrl.Result{}, nil
 		}
 	}
 

--- a/controllers/wasmcloudapplication_controller.go
+++ b/controllers/wasmcloudapplication_controller.go
@@ -81,13 +81,8 @@ func (r *WasmCloudApplicationReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 	}
 
-	response, err := (&request.Sender{
-		Log: log,
-	}).Send(request.Message{
-		Name:        req.Name,
-		Namespace:   req.Namespace,
-		Application: app.DeepCopy(),
-	})
+	sender := request.Sender{Log: log}
+	response, err := sender.Put(&app)
 
 	if err != nil {
 		return ctrl.Result{}, err
@@ -114,14 +109,9 @@ func (r *WasmCloudApplicationReconciler) SetupWithManager(mgr ctrl.Manager) erro
 }
 
 func (r *WasmCloudApplicationReconciler) deleteExternalResources(app *corev1beta1.WasmCloudApplication) error {
-	_, err := (&request.Sender{
-		Log: r.Log,
-	}).Send(request.Message{
-		// FIXME: make this Delete() and make send be Put()
-		Name:        app.Name,
-		Namespace:   app.Namespace,
-		Application: nil,
-	})
+	sender := request.Sender{Log: r.Log}
+	_, err := sender.Delete(app)
+
 	return err
 }
 

--- a/controllers/wasmcloudapplication_controller_test.go
+++ b/controllers/wasmcloudapplication_controller_test.go
@@ -98,8 +98,10 @@ var _ = Describe("Test Create Application", func() {
 					Name:      "latticecontroller",
 				}, &app)
 
-				return err == nil
+				// It takes a few updates before the status is propagated from lattice controller.
+				return err == nil && app.Status.FromLatticeController == "received"
 			}, timeout, interval).Should(BeTrue())
+
 			Expect(len(app.Spec.Components)).Should(Equal(1))
 			Expect(app.Status.FromLatticeController).Should(Equal("received"))
 			connection.Close()

--- a/controllers/wasmcloudapplication_controller_test.go
+++ b/controllers/wasmcloudapplication_controller_test.go
@@ -85,11 +85,9 @@ var _ = Describe("Test Create Application", func() {
 			Status: corev1beta1.WasmCloudApplicationStatus{},
 		}
 	})
-	AfterEach(func() {})
 	Context("Do", func() {
 		It("Should create the application", func() {
-			connection := fakelatticecontroller.Setup()
-			defer connection.Close()
+			connection := fakelatticecontroller.SetupSubscriber()
 
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, application)).Should(Succeed())
@@ -104,6 +102,7 @@ var _ = Describe("Test Create Application", func() {
 			}, timeout, interval).Should(BeTrue())
 			Expect(len(app.Spec.Components)).Should(Equal(1))
 			Expect(app.Status.FromLatticeController).Should(Equal("received"))
+			connection.Close()
 		})
 	})
 })

--- a/controllers/wasmcloudapplication_controller_test.go
+++ b/controllers/wasmcloudapplication_controller_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Test Create Application", func() {
 	})
 	Context("Do", func() {
 		It("Should create the application", func() {
-			connection := fakelatticecontroller.SetupSubscriber()
+			fakecontroller := fakelatticecontroller.SetupSubscriber()
 
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, application)).Should(Succeed())
@@ -104,7 +104,12 @@ var _ = Describe("Test Create Application", func() {
 
 			Expect(len(app.Spec.Components)).Should(Equal(1))
 			Expect(app.Status.FromLatticeController).Should(Equal("received"))
-			connection.Close()
+			fakecontroller.Close()
+
+			// Check that we actually the lattice controller about our app.
+			msg := fakecontroller.SpyNextMessage()
+			Expect(msg).ShouldNot(BeNil())
+			Expect(msg.Subject).Should(Equal("wasmbus.alc.default.put"))
 		})
 	})
 })

--- a/controllers/wasmcloudapplication_controller_test.go
+++ b/controllers/wasmcloudapplication_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"os/exec"
 	"time"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -16,9 +15,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-)
 
-var natsCmd *exec.Cmd
+	fakelatticecontroller "github.com/wasmCloud/wasmcloud-k8s-operator/fake_lattice_controller"
+)
 
 var _ = Describe("Test Create Application", func() {
 	const (
@@ -30,10 +29,6 @@ var _ = Describe("Test Create Application", func() {
 		application *corev1beta1.WasmCloudApplication
 	)
 	BeforeEach(func() {
-		// TODO: replace with something that we have more control/visibility over?
-		natsCmd = exec.Command("nats", "reply", "wasmbus.alc.default.*", "{\"status\":\"received\"}")
-		time.Sleep(1 * time.Second)
-
 		application = &corev1beta1.WasmCloudApplication{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "App",
@@ -90,11 +85,12 @@ var _ = Describe("Test Create Application", func() {
 			Status: corev1beta1.WasmCloudApplicationStatus{},
 		}
 	})
-	AfterEach(func() {
-		natsCmd.Process.Kill()
-	})
+	AfterEach(func() {})
 	Context("Do", func() {
 		It("Should create the application", func() {
+			connection := fakelatticecontroller.Setup()
+			defer connection.Close()
+
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, application)).Should(Succeed())
 			app := corev1beta1.WasmCloudApplication{}

--- a/controllers/wasmcloudapplication_controller_test.go
+++ b/controllers/wasmcloudapplication_controller_test.go
@@ -104,12 +104,27 @@ var _ = Describe("Test Create Application", func() {
 
 			Expect(len(app.Spec.Components)).Should(Equal(1))
 			Expect(app.Status.FromLatticeController).Should(Equal("received"))
-			fakecontroller.Close()
 
 			// Check that we actually the lattice controller about our app.
 			msg := fakecontroller.SpyNextMessage()
 			Expect(msg).ShouldNot(BeNil())
 			Expect(msg.Subject).Should(Equal("wasmbus.alc.default.put"))
+
+			fakecontroller.Close()
+		})
+
+		It("Should delete the application", func() {
+			fakecontroller := fakelatticecontroller.SetupSubscriber()
+
+			ctx := context.Background()
+			Expect(k8sClient.Delete(ctx, application)).Should(Succeed())
+
+			msg := fakecontroller.WaitForMessage()
+
+			Expect(msg).ShouldNot(BeNil())
+			Expect(msg.Subject).Should(Equal("wasmbus.alc.default.del"))
+
+			fakecontroller.Close()
 		})
 	})
 })

--- a/controllers/wasmcloudapplication_controller_test.go
+++ b/controllers/wasmcloudapplication_controller_test.go
@@ -1,0 +1,104 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+
+	corev1beta1 "github.com/wasmCloud/wasmcloud-k8s-operator/api/v1beta1"
+
+	oamv1beta1 "github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Test Create Application", func() {
+	const (
+		timeout  = time.Second * 10
+		duration = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+	var (
+		application *corev1beta1.WasmCloudApplication
+	)
+	BeforeEach(func() {
+		application = &corev1beta1.WasmCloudApplication{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "App",
+				APIVersion: "v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "latticecontroller",
+				Namespace: "default",
+			},
+			Spec: oamv1beta1.ApplicationSpec{
+				Components: []common.ApplicationComponent{
+					{
+						Name: "userinfo",
+						Type: "actor",
+						Properties: util.Object2RawExtension(map[string]interface{}{
+							"image": "wasmcloud.azurecr.io/fake:1",
+						}),
+						Traits: []common.ApplicationTrait{
+							{
+								Type: "spreadscaler",
+								Properties: util.Object2RawExtension(map[string]interface{}{
+									"replicas": 4,
+									"spread": []map[string]interface{}{
+										{
+											"name": "eastcoast",
+											"requirements": map[string]interface{}{
+												"zone": "us-east-1",
+											},
+											"weight": 80,
+										},
+										{
+											"name": "westcoast",
+											"requirements": map[string]interface{}{
+												"zone": "us-west-1",
+											},
+											"weight": 20,
+										},
+									},
+								}),
+							},
+							{
+								Type: "linkdef",
+								Properties: util.Object2RawExtension(map[string]interface{}{
+									"target": "webcap",
+									"values": map[string]interface{}{
+										"port": 8080,
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1beta1.WasmCloudApplicationStatus{},
+		}
+	})
+	AfterEach(func() {})
+	Context("Do", func() {
+		It("Should create the application", func() {
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, application)).Should(Succeed())
+			app := corev1beta1.WasmCloudApplication{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: "default",
+					Name:      "latticecontroller",
+				}, &app)
+
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(len(app.Spec.Components)).Should(Equal(1))
+		})
+	})
+})

--- a/fake_lattice_controller/fake_lattice_controller.go
+++ b/fake_lattice_controller/fake_lattice_controller.go
@@ -14,15 +14,42 @@ func Setup() *server.Server {
 
 }
 
-func SetupSubscriber() *nats.Conn {
+type FakeLatticeController struct {
+	conn     *nats.Conn
+	messages chan *nats.Msg
+}
+
+// Finish the test and close connections.
+func (f *FakeLatticeController) Close() {
+	f.conn.Close()
+	close(f.messages)
+}
+
+// Return the next message that was received over NATS.
+// If you SpyNextMessage() and there are no more messages, this function
+// will return nil.
+// Be sure to call FakeLatticeController.Close() before using this
+// method, and do all of your assertions at the end of the test,
+// to avoid hard-to-debug timeouts. If you do not call Close, this
+// method may time out, rather than returning nil.
+func (f *FakeLatticeController) SpyNextMessage() *nats.Msg {
+	result := <-f.messages
+	return result
+}
+
+// Set up a fake lattice controller.
+// Returns the nats connection for the lattice controller,
+// and a channel for spying on the received messages.
+func SetupSubscriber() *FakeLatticeController {
 	connection, err := nats.Connect(nats.DefaultURL)
 	if err != nil {
 		panic("Unable to connect to NATS server")
 	}
-
+	messages := make(chan *nats.Msg, 1000)
 	connection.Subscribe("wasmbus.alc.default.*", func(req *nats.Msg) {
+		messages <- req
 		connection.Publish(req.Reply, []byte("{\"status\": \"received\"}"))
 	})
 
-	return connection
+	return &FakeLatticeController{connection, messages}
 }

--- a/fake_lattice_controller/fake_lattice_controller.go
+++ b/fake_lattice_controller/fake_lattice_controller.go
@@ -1,17 +1,23 @@
 package fakelatticecontroller
 
 import (
+	"github.com/nats-io/gnatsd/server"
 	natsserver "github.com/nats-io/nats-server/test"
 	"github.com/nats-io/nats.go"
 )
 
-func Setup() *nats.Conn {
+func Setup() *server.Server {
 	server := natsserver.RunDefaultServer()
 	server.Start()
 
+	return server
+
+}
+
+func SetupSubscriber() *nats.Conn {
 	connection, err := nats.Connect(nats.DefaultURL)
 	if err != nil {
-		panic(err)
+		panic("Unable to connect to NATS server")
 	}
 
 	connection.Subscribe("wasmbus.alc.default.*", func(req *nats.Msg) {

--- a/fake_lattice_controller/fake_lattice_controller.go
+++ b/fake_lattice_controller/fake_lattice_controller.go
@@ -1,8 +1,8 @@
 package fakelatticecontroller
 
 import (
-	"github.com/nats-io/gnatsd/server"
-	natsserver "github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats-server/v2/server"
+	natsserver "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 )
 

--- a/fake_lattice_controller/fake_lattice_controller.go
+++ b/fake_lattice_controller/fake_lattice_controller.go
@@ -1,0 +1,22 @@
+package fakelatticecontroller
+
+import (
+	natsserver "github.com/nats-io/nats-server/test"
+	"github.com/nats-io/nats.go"
+)
+
+func Setup() *nats.Conn {
+	server := natsserver.RunDefaultServer()
+	server.Start()
+
+	connection, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		panic(err)
+	}
+
+	connection.Subscribe("wasmbus.alc.default.*", func(req *nats.Msg) {
+		connection.Publish(req.Reply, []byte("{\"status\": \"received\"}"))
+	})
+
+	return connection
+}

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0
-	github.com/nats-io/gnatsd v1.4.1 // indirect
-	github.com/nats-io/nats-server v1.4.1
-	github.com/nats-io/nats-server/v2 v2.5.0 // indirect
+	github.com/nats-io/nats-server/v2 v2.5.0
 	github.com/nats-io/nats.go v1.12.1
 	github.com/oam-dev/kubevela v1.1.0
 	github.com/onsi/ginkgo v1.16.4

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0
+	github.com/nats-io/gnatsd v1.4.1 // indirect
+	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats-server/v2 v2.5.0 // indirect
 	github.com/nats-io/nats.go v1.12.1
 	github.com/oam-dev/kubevela v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -534,6 +534,7 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -865,16 +866,12 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/nats-io/gnatsd v1.4.1 h1:RconcfDeWpKCD6QIIwiVFcvForlXpWeJP7i5/lDLy44=
-github.com/nats-io/gnatsd v1.4.1/go.mod h1:nqco77VO78hLCJpIcVfygDP2rPGfsEHkGTUk94uh5DQ=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/jwt v1.2.2 h1:w3GMTO969dFg+UOKTmmyuu7IGdusK+7Ytlt//OYH/uU=
 github.com/nats-io/jwt v1.2.2/go.mod h1:/xX356yQA6LuXI9xWW7mZNpxgF2mBmGecH+Fj34sP5Q=
 github.com/nats-io/jwt/v2 v2.0.3 h1:i/O6cmIsjpcQyWDYNcq2JyZ3/VTF8SJ4JWluI5OhpvI=
 github.com/nats-io/jwt/v2 v2.0.3/go.mod h1:VRP+deawSXyhNjXmxPCHskrR6Mq50BqpEI5SEcNiGlY=
-github.com/nats-io/nats-server v1.4.1 h1:Ul1oSOGNV/L8kjr4v6l2f9Yet6WY+LevH1/7cRZ/qyA=
-github.com/nats-io/nats-server v1.4.1/go.mod h1:c8f/fHd2B6Hgms3LtCaI7y6pC4WD1f4SUxcCud5vhBc=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
 github.com/nats-io/nats-server/v2 v2.5.0 h1:wsnVaaXH9VRSg+A2MVg5Q727/CqxnmPLGFQ3YZYKTQg=
 github.com/nats-io/nats-server/v2 v2.5.0/go.mod h1:Kj86UtrXAL6LwYRA6H4RqzkHhK0Vcv2ZnKD5WbQ1t3g=

--- a/go.sum
+++ b/go.sum
@@ -865,12 +865,16 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nats-io/gnatsd v1.4.1 h1:RconcfDeWpKCD6QIIwiVFcvForlXpWeJP7i5/lDLy44=
+github.com/nats-io/gnatsd v1.4.1/go.mod h1:nqco77VO78hLCJpIcVfygDP2rPGfsEHkGTUk94uh5DQ=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/jwt v1.2.2 h1:w3GMTO969dFg+UOKTmmyuu7IGdusK+7Ytlt//OYH/uU=
 github.com/nats-io/jwt v1.2.2/go.mod h1:/xX356yQA6LuXI9xWW7mZNpxgF2mBmGecH+Fj34sP5Q=
 github.com/nats-io/jwt/v2 v2.0.3 h1:i/O6cmIsjpcQyWDYNcq2JyZ3/VTF8SJ4JWluI5OhpvI=
 github.com/nats-io/jwt/v2 v2.0.3/go.mod h1:VRP+deawSXyhNjXmxPCHskrR6Mq50BqpEI5SEcNiGlY=
+github.com/nats-io/nats-server v1.4.1 h1:Ul1oSOGNV/L8kjr4v6l2f9Yet6WY+LevH1/7cRZ/qyA=
+github.com/nats-io/nats-server v1.4.1/go.mod h1:c8f/fHd2B6Hgms3LtCaI7y6pC4WD1f4SUxcCud5vhBc=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
 github.com/nats-io/nats-server/v2 v2.5.0 h1:wsnVaaXH9VRSg+A2MVg5Q727/CqxnmPLGFQ3YZYKTQg=
 github.com/nats-io/nats-server/v2 v2.5.0/go.mod h1:Kj86UtrXAL6LwYRA6H4RqzkHhK0Vcv2ZnKD5WbQ1t3g=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
+cuelang.org/go v0.2.2 h1:i/wFo48WDibGHKQTRZ08nB8PqmGpVpQ2sRflZPj73nQ=
 cuelang.org/go v0.2.2/go.mod h1:Dyjk8Y/B3CfFT1jQKJU0g5PpCeMiDe0yMOhk57oXwqo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
@@ -201,7 +202,9 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
+github.com/cockroachdb/apd/v2 v2.0.1 h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWqLTE=
 github.com/cockroachdb/apd/v2 v2.0.1/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -238,6 +241,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/crossplane/crossplane-runtime v0.14.1-0.20210722005935-0b469fcc77cd h1:2ZdR/HyjXFIo6KxmM08jBLeiJs7GRdGmb6qPKQANGvI=
 github.com/crossplane/crossplane-runtime v0.14.1-0.20210722005935-0b469fcc77cd/go.mod h1:0sB8XOV2zy1GdZvSMY0/5QzKQJUiNSek08wbAYHJbws=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -736,6 +740,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -756,6 +761,7 @@ github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdA
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
@@ -851,6 +857,7 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mozillazg/go-cos v0.13.0/go.mod h1:Zp6DvvXn0RUOXGJ2chmWt2bLEqRAnJnS3DnAZsJsoaE=
 github.com/mozillazg/go-httpheader v0.2.1/go.mod h1:jJ8xECTlalr6ValeXYdOF8fFUISeBAdw6E61aqQma60=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/lattice_client/lattice_client.go
+++ b/lattice_client/lattice_client.go
@@ -1,4 +1,4 @@
-package request
+package latticeclient
 
 import (
 	"encoding/json"
@@ -20,21 +20,21 @@ type response struct {
 	Status string `json:"status"`
 }
 
-type Sender struct {
+type Client struct {
 	Log logr.Logger
 }
 
-func (s *Sender) Put(app *corev1beta1.WasmCloudApplication) (response, error) {
-	r, e := s.send("put", app)
+func (c *Client) Put(app *corev1beta1.WasmCloudApplication) (response, error) {
+	r, e := c.send("put", app)
 	return r, e
 }
-func (s *Sender) Delete(app *corev1beta1.WasmCloudApplication) (response, error) {
-	r, e := s.send("delete", app)
+func (c *Client) Delete(app *corev1beta1.WasmCloudApplication) (response, error) {
+	r, e := c.send("delete", app)
 	return r, e
 }
 
-func (s *Sender) send(verb string, app *corev1beta1.WasmCloudApplication) (response, error) {
-	log := s.Log.WithValues("requesting wasmcloud-lattice-controller to reconcile", app)
+func (c *Client) send(verb string, app *corev1beta1.WasmCloudApplication) (response, error) {
+	log := c.Log.WithValues("requesting wasmcloud-lattice-controller to reconcile", app)
 
 	data, err := json.Marshal(app)
 	if err != nil {
@@ -57,6 +57,8 @@ func (s *Sender) send(verb string, app *corev1beta1.WasmCloudApplication) (respo
 		log.Info("invalid json from lattice controller", "error", err)
 		return response, err
 	}
+
+	log.Info("response from the lattice controller", "application", response.Status)
 
 	return response, nil
 }

--- a/lattice_client/lattice_client.go
+++ b/lattice_client/lattice_client.go
@@ -29,7 +29,7 @@ func (c *Client) Put(app *corev1beta1.WasmCloudApplication) (response, error) {
 	return r, e
 }
 func (c *Client) Delete(app *corev1beta1.WasmCloudApplication) (response, error) {
-	r, e := c.send("delete", app)
+	r, e := c.send("del", app)
 	return r, e
 }
 


### PR DESCRIPTION
fake_lattice_controller.go sets up the equivalent of `nats-server` and `nats reply wasmbus.alc.default.* {"status":"received"}` , but in go. It is also possible to spy on messages that have been received, and assert that they have happened.

We thought about allowing the test to reply with custom responses, but it tempts you into writing complicated mocking logic in the test. Much easier to maintain if we make a simple Fake implementation and then spy on it.